### PR TITLE
Cocoapods support

### DIFF
--- a/MISAlertController.podspec
+++ b/MISAlertController.podspec
@@ -1,0 +1,135 @@
+#
+#  Be sure to run `pod spec lint MISAlertController.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see http://docs.cocoapods.org/specification.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+Pod::Spec.new do |s|
+
+  # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  These will help people to find your library, and whilst it
+  #  can feel like a chore to fill in it's definitely to your advantage. The
+  #  summary should be tweet-length, and the description more in depth.
+  #
+
+  s.name         = "MISAlertController"
+  s.version      = "1.0.0-beta1"
+  s.summary      = "Add support for UIAlertController API to iOS7+. Uses UIAlertController (iOS 8+) and UIAlertView / UIAlertSheet (iOS 7) behind the scenes."
+
+  s.description  = <<-DESC
+                    If you want to use UIAlertController, but still need to support iOS 7 this project is for you.
+
+                    MISAlertController is a wrapper around UIAlertController and UIAlertView / UIActionSheet. On iOS 7 MISAlertController uses UIAlertView or UIActionSheet and on iOS 8 it uses UIAlertController to show Alerts and Action Sheets.
+
+                    MISAlertController uses ARC and supports iOS 7.0+
+                   DESC
+
+  s.homepage     = "https://github.com/maicki/MISAlertController"
+  # s.screenshots  = "www.example.com/screenshots_1.gif", "www.example.com/screenshots_2.gif"
+
+
+  # ―――  Spec License  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Licensing your code is important. See http://choosealicense.com for more info.
+  #  CocoaPods will detect a license file if there is a named LICENSE*
+  #  Popular ones are 'MIT', 'BSD' and 'Apache License, Version 2.0'.
+  #
+
+  s.license      = "MIT"
+  # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
+
+
+  # ――― Author Metadata  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Specify the authors of the library, with email addresses. Email addresses
+  #  of the authors are extracted from the SCM log. E.g. $ git log. CocoaPods also
+  #  accepts just a name if you'd rather not provide an email address.
+  #
+  #  Specify a social_media_url where others can refer to, for example a twitter
+  #  profile URL.
+  #
+
+  s.authors             = { "Michael Schneider" => "mischneider1@gmail.com", "Rafael Winter" => "rafael.winter@gmail.com"}
+  # Or just: s.author    = "Rafael Winter"
+  # s.authors            = { "Rafael Winter" => "winter@telefonicabeta.com" }
+  # s.social_media_url   = "http://twitter.com/Rafael Winter"
+
+  # ――― Platform Specifics ――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  If this Pod runs only on iOS or OS X, then specify the platform and
+  #  the deployment target. You can optionally include the target after the platform.
+  #
+
+  # s.platform     = :ios
+  s.platform     = :ios, "7.0"
+
+  #  When using multiple platforms
+  # s.ios.deployment_target = "5.0"
+  # s.osx.deployment_target = "10.7"
+
+
+  # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Specify the location from where the source should be retrieved.
+  #  Supports git, hg, bzr, svn and HTTP.
+  #
+
+  s.source       = { :git => "https://github.com/rafaelwinter/MISAlertController.git", :tag => "1.0.0-beta1" }
+
+
+  # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  CocoaPods is smart about how it includes source code. For source files
+  #  giving a folder will include any h, m, mm, c & cpp files. For header
+  #  files it will include any header in the folder.
+  #  Not including the public_header_files will make all headers public.
+  #
+
+  s.source_files  = "MISAlertController"
+  #s.exclude_files = "Classes/Exclude"
+
+  # s.public_header_files = "Classes/**/*.h"
+
+
+  # ――― Resources ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  A list of resources included with the Pod. These are copied into the
+  #  target bundle with a build phase script. Anything else will be cleaned.
+  #  You can preserve files from being cleaned, please don't preserve
+  #  non-essential files like tests, examples and documentation.
+  #
+
+  # s.resource  = "icon.png"
+  # s.resources = "Resources/*.png"
+
+  # s.preserve_paths = "FilesToSave", "MoreFilesToSave"
+
+
+  # ――― Project Linking ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Link your library with frameworks, or libraries. Libraries do not include
+  #  the lib prefix of their name.
+  #
+
+  # s.framework  = "SomeFramework"
+  # s.frameworks = "SomeFramework", "AnotherFramework"
+
+  # s.library   = "iconv"
+  # s.libraries = "iconv", "xml2"
+
+
+  # ――― Project Settings ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  If your library depends on compiler flags you can set them in the xcconfig hash
+  #  where they will only apply to your library. If you depend on other Podspecs
+  #  you can include multiple dependencies to ensure it works.
+
+ s.requires_arc = true
+
+  # s.xcconfig = { "HEADER_SEARCH_PATHS" => "$(SDKROOT)/usr/include/libxml2" }
+  # s.dependency "JSONKit", "~> 1.4"
+
+end

--- a/README.md
+++ b/README.md
@@ -7,6 +7,17 @@ MISAlertController is a wrapper around UIAlertController and UIAlertView / UIAct
 
 MISAlertController uses ARC and supports iOS 7.0+
 
+## Installing
+
+MISAlertController can be installed by [CocoaPods](www.cocoapods.org). Simply add this line to your `Podfile`:
+````
+pod "MISAlertController", "~> 1.0"
+````
+
+And run `pod install`.
+
+It is also possible to copy the source files on the MISAlertController folder directly to your sources.
+
 ## Usage
 
 First create a ``MISAlertController`` object


### PR DESCRIPTION
This PR creates the `podspec` for MISAlertController.

Testing is straightforward, create a new xcode project and initialize a Podfile. Then add a reference to my fork, like this:

````
pod 'MISAlertController', :git => 'https://github.com/rafaelwinter/MISAlertController.git', :branch => 'cocoapods_support'
````

CocoaPods requires proper source tagging. Once this podspec is tested and accepted, we should tag the master repo and distribute the podspec.
